### PR TITLE
Fixes for OSX's tar-command and site-cookbooks

### DIFF
--- a/littlechef.py
+++ b/littlechef.py
@@ -599,8 +599,6 @@ def _print_node(node):
 def _get_recipes_in_cookbook(name):
     '''Gets the name of all recipes present in a cookbook'''
     recipes = []
-    if not os.path.exists('cookbooks/' + name):
-        abort('Cookbook "{0}" not found'.format(name))
     path = None
     for cookbook_path in _cookbook_paths:
         path = '{0}/{1}/metadata.json'.format(cookbook_path, name)


### PR DESCRIPTION
Two fixes:
1. OSXs tar command causes files named `._{filename}` to be stored in the tar. Gnu-Tar has a --no-xattrs option, OSX's tar doesn't have that. Setting an ENV-var will prevent OSX's tar's behavior. Gnu-Tar shouldn't have any issues with that var.
2. If a cookbook only existed in `site-cookbooks` an exception was thrown, because a check for existence in `cookbooks` was hardcoded. The code after that works with the _cookbook_path and will raise an exception if no cookbook/metadata.json is found. It should cover the previous check much better.
