### PR TITLE
list.append expected node file to possible paths

### DIFF
--- a/littlechef/chef.py
+++ b/littlechef/chef.py
@@ -40,7 +40,7 @@ def _save_config(node):
     files = ['tmp_node.json']
     if not os.path.exists(filepath):
         # Only save to nodes/ if there is not already a file
-        files += filepath
+        files.append(filepath)
     for node_file in files:
         with open(node_file, 'w') as f:
             f.write(json.dumps(node, indent=4))


### PR DESCRIPTION
The += statement that was there previously ended up with an array that looked like `['tmp_node.json', 'n', 'o', 'd', 'e', 's', '/', '1', '0', '.', '0', '.', '0', '.', '1', '4', '.', 'j', 's', 'o', 'n']` causing it to try to read the root directory.
