### PR TITLE
Fix issue 48 - broken permissions on /tmp/chef-solo

### DIFF
--- a/littlechef/solo.py
+++ b/littlechef/solo.py
@@ -65,7 +65,9 @@ def configure():
             'cookbook_paths_list': cookbook_paths_list}
         upload_template(os.path.join(BASEDIR, 'solo.rb'), '/etc/chef/',
             context=data, use_sudo=True, mode=0400)
+        remote_username = run('whoami').strip()
         sudo('chown root:root {0}'.format('/etc/chef/solo.rb'))
+        sudo('chown -R {0}.{0} {1}'.format(remote_username, node_work_path))
 
 
 def check_distro():


### PR DESCRIPTION
this fixes https://github.com/tobami/littlechef/issues/48 by simply resetting the permission on /tmp/chef-solo appropriately at the end of deploy_chef
