### PR TITLE
Allow user to override autodetection of distro_type/distro in deploy_chef

### DIFF
--- a/littlechef/runner.py
+++ b/littlechef/runner.py
@@ -93,7 +93,10 @@ def deploy_chef(gems="no", ask="yes", version="0.10"):
     if version not in chef_versions:
         abort('Wrong Chef version specified. Valid versions are {0}'.format(
             ", ".join(chef_versions)))
-    distro_type, distro = solo.check_distro()
+    if distro_type is None and distro is None:
+        distro_type, distro = solo.check_distro()
+    elif distro_type is None or distro is None:
+        abort('Must specify both or neither of distro_type and distro')
     if ask == "yes":
         message = '\nAre you sure you want to install Chef {0}'.format(version)
         message += ' at the node {0}'.format(env.host_string)


### PR DESCRIPTION
Allow user to override autodetection of distro_type/distro in deploy_chef.

I need this because I'm testing out an unreleased version of Oneiric, but
Opscode have no upstream repo for this yet, so I need to tell littlechef
to pretend it's on Natty.

Use like so:

cook node:10.100.2.13 deploy_chef:distro_type=debian,distro=natty
