### PR TITLE
Added report logging to /tmp/chef.log.

### DIFF
--- a/fix
+++ b/fix
@@ -40,6 +40,9 @@ else:
             if arg in sys.argv: 
                 print(VERSION.format(littlechef.__version__))
                 sys.exit(0)
+        if '--no-report' in sys.argv:
+            littlechef.enable_report = False
+            sys.argv.remove('--no-report')
         for arg in sys.argv:
             if "env:" in arg:
                 chef_environment = arg.split(":")[1]
@@ -48,7 +51,7 @@ else:
                     sys.exit(1)
                 else:
                     littlechef.chef_environment = chef_environment
-                sys.argv.remove(arg)
+                sys.argv.remove(arg)            
         # Otherwise, insert our fabfile at the correct place
         if fix_cmd:
             sys.argv[1:1] = ['-f', fabfile]

--- a/littlechef/__init__.py
+++ b/littlechef/__init__.py
@@ -20,3 +20,7 @@ __author__ = "Miquel Torres <tobami@gmail.com>"
 __cooking__ = False
 
 chef_environment = None
+
+REPORT = '/tmp/chef.log'
+enable_report = True
+

--- a/littlechef/chef.py
+++ b/littlechef/chef.py
@@ -28,10 +28,10 @@ from fabric.contrib.project import rsync_project
 from littlechef import lib
 from littlechef import solo
 from littlechef.settings import node_work_path, cookbook_paths
+from littlechef import REPORT, enable_report as ENABLE_REPORT
 
 # Path to local patch
 basedir = os.path.abspath(os.path.dirname(__file__).replace('\\', '/'))
-
 
 def save_config(node, force=False):
     """Saves node configuration
@@ -296,8 +296,12 @@ def _configure_node():
     """Exectutes chef-solo to apply roles and recipes to a node"""
     print("\nCooking...")
     with settings(hide('warnings', 'running'), warn_only=True):
-        output = sudo(
-            'chef-solo -l {0} -j /etc/chef/node.json'.format(env.loglevel))
+        cmd = 'chef-solo -l {0} -j /etc/chef/node.json'.format(env.loglevel)
+        if ENABLE_REPORT:
+            cmd += ' | tee {0}'.format(REPORT)
+        else:
+            sudo("rm -f {0}".format(REPORT))
+        output = sudo(cmd)
         if output.failed:
             if 'chef-solo: command not found' in output:
                 print(


### PR DESCRIPTION
Per default fix will always log the output of chef-solo to /tmp/chef.log. But also an option has been added to no create this lof file.
