### PR TITLE
Fix's issue #101

### DIFF
--- a/littlechef/solo.py
+++ b/littlechef/solo.py
@@ -281,7 +281,7 @@ def _add_rpm_repos():
 
     epel_release = "epel-release-5-4.noarch"
     if rhel_version == "6":
-        epel_release = "epel-release-6-5.noarch"
+        epel_release = "epel-release-6-7.noarch"
     with show('running'):
         # Install the EPEL Yum Repository.
         with settings(hide('warnings', 'running'), warn_only=True):


### PR DESCRIPTION
This should resolve issue #101, the epel release url is now 6.7 not 6.5. This tweak fixed the issue for me using CentOS 6.2 when running the deploy_chef command.
