### PR TITLE
SSH config's LogLevel should not override env's loglevel

### DIFF
--- a/littlechef/lib.py
+++ b/littlechef/lib.py
@@ -454,6 +454,10 @@ def credentials(*args, **kwargs):
         # translate from ssh params to fabric params
         if 'identityfile' in credentials:
             credentials['key_filename'] = credentials['identityfile']
+        # SSH LogLevel != overall env loglevel, so don't override the env's
+        # loglevel with SSH's
+        if 'loglevel' in credentials:
+            del credentials['loglevel']
         credentials.update(kwargs)
     else:
         credentials = kwargs


### PR DESCRIPTION
`lib.credentials` returns a context manager that temporarily overrides parameters in `env` with parameters in the SSH config file.  However, there is a conflict because an SSH Config file can have a loglevel option whose values do not match chef's log level values:

From http://linux.die.net/man/5/ssh_config:

**LogLevel**
Gives the verbosity level that is used when logging messages from ssh(1). The possible values are: QUIET, FATAL, ERROR, INFO, VERBOSE, DEBUG, DEBUG1, DEBUG2, and DEBUG3. The default is INFO. DEBUG and DEBUG1 are equivalent. DEBUG2 and DEBUG3 each specify higher levels of verbose output.

For example, currently if your ssh config has the following:

```
Host myhost
    HostName 172.16.86.164
    User myuser
    Port 22
    UserKnownHostsFile /dev/null
    StrictHostKeyChecking no
    PasswordAuthentication no
    LogLevel ERROR
```

The following error appears when trying to fix that node:

```
$ fix --debug node:myhost role:base

== Applying role 'base' to myhost ==
Synchronizing node, cookbooks, roles and data bags...

Cooking...
/usr/lib/ruby/gems/1.8/gems/mixlib-log-1.4.1/lib/mixlib/log.rb:97:in `level=': Log level must be one of :debug, :info, :warn, :error, or :fatal (ArgumentError)
from /usr/lib/ruby/gems/1.8/gems/chef-10.16.0/bin/../lib/chef/application.rb:119:in `configure_logging'
from /usr/lib/ruby/gems/1.8/gems/chef-10.16.0/bin/../lib/chef/application.rb:65:in `reconfigure'
from /usr/lib/ruby/gems/1.8/gems/chef-10.16.0/bin/../lib/chef/application/solo.rb:155:in `reconfigure'
from /usr/lib/ruby/gems/1.8/gems/chef-10.16.0/bin/../lib/chef/application.rb:70:in `run'
from /usr/lib/ruby/gems/1.8/gems/chef-10.16.0/bin/chef-solo:25
from /usr/bin/chef-solo:19:in `load'
from /usr/bin/chef-solo:19
```

Deleting the LogLevel line in the ssh config results in this error going away.

It seems like the SSH config's LogLevel should be just ignored, since that just specifies what level of logging SSH should display and not what level of logging Chef should display.
