### PR TITLE
Changes implement support for following symlinks on rsync

### DIFF
--- a/littlechef/chef.py
+++ b/littlechef/chef.py
@@ -121,11 +121,14 @@ def _synchronize_node(configfile, node):
     # Remove local temporary node file
     os.remove(configfile)
     # Synchronize kitchen
+    extra_opts = "-q"
+    if env.follow_symlinks:
+        extra_opts += " --copy-links"
     rsync_project(
         env.node_work_path, './cookbooks ./data_bags ./roles ./site-cookbooks',
         exclude=('*.svn', '.bzr*', '.git*', '.hg*'),
         delete=True,
-        extra_opts="-q",
+        extra_opts=extra_opts,
     )
     _add_search_patch()
 

--- a/littlechef/runner.py
+++ b/littlechef/runner.py
@@ -388,6 +388,12 @@ def _readconfig():
     else:
         if not env.node_work_path:
             abort('The "node_work_path" option cannot be empty')
+    
+    # Follow symlinks
+    try:
+        env.follow_symlinks = config.getboolean('kitchen', 'follow_symlinks')
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+        env.follow_symlinks = False
 
 
 # Only read config if fix is being used and we are not creating a new kitchen


### PR DESCRIPTION
That's issue #64.

Default behavior is off. Feature can be enabled via  config file, section kitchen, option follow_symlinks
