### PR TITLE
`default_attributes` and `override_attributes` are required in all roles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@
 LittleChef Changelog
 ====================
 
+Version 1.?
+-----------
+
+Bugs fixed:
+* `default_attributes` and `override_attributes` are no longer required in
+  JSON role definitions.
+
 Version 1.3.0 October 26, 2012
 ----------------------------------------
 New features:

--- a/littlechef/chef.py
+++ b/littlechef/chef.py
@@ -20,7 +20,7 @@ import shutil
 import simplejson as json
 
 from fabric.api import *
-from fabric.contrib.files import append, exists
+from fabric.contrib.files import exists
 from fabric import colors
 from fabric.utils import abort
 from fabric.contrib.project import rsync_project
@@ -211,7 +211,7 @@ def _add_merged_attributes(node, all_recipes, all_roles):
     for role in node['roles']:
         for r in all_roles:
             if role == r['name']:
-                update_dct(attributes, r['default_attributes'])
+                update_dct(attributes, r.get('default_attributes', {}))
 
     # Get normal node attributes
     non_attribute_fields = [
@@ -227,7 +227,7 @@ def _add_merged_attributes(node, all_recipes, all_roles):
     for role in node['roles']:
         for r in all_roles:
             if role == r['name']:
-                update_dct(attributes, r['override_attributes'])
+                update_dct(attributes, r.get('override_attributes', {}))
     # Merge back to the original node object
     node.update(attributes)
 


### PR DESCRIPTION
According to the [documentation](http://wiki.opscode.com/display/chef/Roles), both `default_attributes` and `override_attributes` are optional in a role definition. Without this patch, it's not possible to use a role that doesn't have both of those variables defined.
