### PR TITLE
Read sudo_prefix from config file

### DIFF
--- a/littlechef/runner.py
+++ b/littlechef/runner.py
@@ -360,6 +360,12 @@ def _readconfig():
             abort(msg)
 
     try:
+        sudo_prefix = config.get('ssh', 'sudo_prefix', raw=True)
+        env.sudo_prefix = sudo_prefix
+    except ConfigParser.NoOptionError:
+        pass
+
+    try:
         env.user = config.get('userinfo', 'user')
         user_specified = True
     except ConfigParser.NoOptionError:


### PR DESCRIPTION
This is first step to allow to overwrite some `Fabric` default values via config file. I personally needed to set [sudo_prefix](http://docs.fabfile.org/en/1.5/usage/env.html#sudo-prefix) in config file:

```
[ssh]
sudo_prefix =sudo -E -S -p '%(sudo_prompt)s'
```

The additional `-E` switch for `sudo` preserves environment variable which in my case was `SSH_AUTH_SOCK` that I needed so that `chef` user can log into another machines using `ForwardAgent` ssh option when running one of the recipe.
