### PR TITLE
Don't ignore user name from node connection string

### DIFF
--- a/littlechef/runner.py
+++ b/littlechef/runner.py
@@ -125,6 +125,8 @@ def node(*nodes):
         for hostname in env.hosts:
             env.host = hostname
             env.host_string = hostname
+            if '@' in hostname:
+                env.user = hostname.split('@')[0]
             node = lib.get_node(env.host)
             lib.print_header("Configuring {0}".format(env.host))
             if __testing__:


### PR DESCRIPTION
When configuring pre-configured node and using node connection string like remote_username@hostname, local user is used instead of remote_username for ssh connection.
