### PR TITLE
Make save_config sort JSON keys

### DIFF
--- a/littlechef/chef.py
+++ b/littlechef/chef.py
@@ -50,7 +50,7 @@ def save_config(node, force=False):
         files_to_create.append(filepath)
     for node_file in files_to_create:
         with open(node_file, 'w') as f:
-            f.write(json.dumps(node, indent=4))
+            f.write(json.dumps(node, indent=4, sort_keys=True))
     return tmp_filename
 
 


### PR DESCRIPTION
We only want node files to change if something actually changes and
preferably in a predictable way. Sorting the json keys makes this much
more consistent.
