### PR TITLE
added debuglevel to ohai ipaddress call

### DIFF
--- a/littlechef/chef.py
+++ b/littlechef/chef.py
@@ -61,7 +61,7 @@ def _get_ipaddress(node):
     """
     if "ipaddress" not in node:
         with settings(hide('stdout'), warn_only=True):
-            output = sudo('ohai ipaddress')
+            output = sudo('ohai -l warn ipaddress')
         if output.succeeded:
             try:
                 node['ipaddress'] = json.loads(output)[0]


### PR DESCRIPTION
On my ec2 instance ( Ubuntu 12.04.1 LTS ), the _ohai_ command sends an additional info output, which breaks _get_ipaddess()

``` shell
ubuntu@ip-10-11-12-123:~$ ohai ipaddress
[Mon, 21 Jan 2013 09:28:28 +0000] INFO: [inet6] no default interface, picking the first ipaddress
[
  "10.11.12.123"
]
```

Adding _-l warn_ suppresses this.
