### PR TITLE
Using node:all with concurrency flag fails because prompt can't be displayed

### DIFF
--- a/littlechef/lib.py
+++ b/littlechef/lib.py
@@ -20,6 +20,7 @@ import imp
 
 from fabric import colors
 from fabric.api import env, settings
+from fabric.contrib.console import confirm
 from fabric.utils import abort
 
 from littlechef import cookbook_paths
@@ -419,6 +420,14 @@ def get_cookbook_path(cookbook_name):
             return path
     raise IOError('Can\'t find cookbook with name "{0}"'.format(cookbook_name))
 
+def global_confirm(question, default=True):
+    """Shows a confirmation that applies to all hosts
+    by temporarily disabling parallel execution in Fabric"""
+    original_parallel = env.parallel
+    env.parallel = False
+    result = confirm(question, default)
+    env.parallel = original_parallel
+    return result
 
 def _pprint(dic):
     """Prints a dictionary with one indentation level"""

--- a/littlechef/runner.py
+++ b/littlechef/runner.py
@@ -113,7 +113,7 @@ def node(*nodes):
             message += " in the {0} environment".format(env.chef_environment)
         message += "?"
         if not __testing__:
-            if not confirm(message):
+            if not lib.global_confirm(message):
                 abort('Aborted by user')
     else:
         # A list of nodes was given


### PR DESCRIPTION
When trying to run the following command:

``` bash
fix --concurrency 4 node:all
```

The following error appears while trying to display the _Are you sure you want to configure all nodes_ prompt.

``` bash
Fatal error: Needed to prompt for a user-specified prompt() call (host: None), but input would be ambiguous in parallel mode

Aborting.
```
