### PR TITLE
Scientific Linux is not correctly identified

### DIFF
--- a/littlechef/solo.py
+++ b/littlechef/solo.py
@@ -123,7 +123,7 @@ def check_distro():
         elif 'Red Hat Enterprise Linux' in output:
             distro = "Red Hat"
             distro_type = "rpm"
-        elif 'Scientific Linux SL' in output:
+        elif 'Scientific Linux' in output:
             distro = "Scientific Linux"
             distro_type = "rpm"
         elif 'This is \\n.\\O (\\s \\m \\r) \\t' in output:


### PR DESCRIPTION
Scientific Linux no longer includes the text "Scientific Linux SL" in /etc/issue. This corrects the distro identication. 
