### PR TITLE
Migrate to argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,6 @@ or
 
 pip will then take care of the extra Python dependencies
 
-The `argparse` library should be installed separately if running with Python 2.6:
-`pip install argparse`
-
 ### Installation
 
 You can install LittleChef directly from the PyPI:  

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url="http://github.com/tobami/littlechef",
     download_url="http://github.com/tobami/littlechef/tags",
     keywords=["chef", "devops", "operations", "sysadmin"],
-    install_requires=['fabric==1.5.4', 'simplejson>=2.1.0'],
+    install_requires=['fabric==1.5.4', 'simplejson>=2.1.0', 'argparse'],
     packages=['littlechef'],
     package_data={
         'littlechef': ['search.rb', 'solo.rb', 'parser.rb', 'environment.rb']
@@ -34,7 +34,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         'Topic :: System :: Systems Administration',
-        ],
+    ],
     long_description="""\
 Cook with Chef without a Chef Server
 -------------------------------------


### PR DESCRIPTION
This branch follows the [Upgrading optparse code](http://docs.python.org/2/library/argparse.html#upgrading-optparse-code) directives.

Users with Python 2.6 should install `argparse` using `pip` (`pip install argparse`). Python 2.7+ already include `argparse`. My approach here is to install argparse as a dependency (which will be already resolved in greater Python versions).

`argparse.RawDescriptionHelpFormatter` allows the `description` and `epilogue` to have their own format (to not being printed in one line). 

The `epilogue` will print `fabric`'s available commands.
