### PR TITLE
Fix argparse bugs

### DIFF
--- a/fix
+++ b/fix
@@ -44,6 +44,8 @@ def parse_arguments():
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
+    parser.add_argument("command", type=str, help="Littlechef command")
+
     parser.add_argument(
         "-v", "--version", action='version',
         version=VERSION.format(littlechef.__version__),


### PR DESCRIPTION
Fixes #172
- Fixed a bug in which the version was retrieved twice, raising a `KeyError`. `argparse` does it automatically with `action=version`, without creating any `version` key in the `args` dictionary.
- Fixed a bug when returning the parsed arguments in `parse_arguments()`
- The arguments are now accessed properly
- Added a `command` positional argument

TODO (I will coordinate this with @thekorn, as he knows more about how the current argument parsing works)
- Retrieve the `command` argument
- We can probably clean up the argument parsing a bit more, relying on `argparse`'s power
