### PR TITLE
WIP: Berksfile support

### DIFF
--- a/littlechef/chef.py
+++ b/littlechef/chef.py
@@ -18,6 +18,8 @@ See http://wiki.opscode.com/display/chef/Anatomy+of+a+Chef+Run
 import os
 import shutil
 import json
+import subprocess
+import shutil
 from copy import deepcopy
 
 from fabric.api import *
@@ -127,9 +129,14 @@ def _synchronize_node(configfile, node):
             use_sudo=True,
             mode=0600)
         sudo('chown root:$(id -g -n root) /etc/chef/encrypted_data_bag_secret')
+
+    paths_to_sync = ['./data_bags', './roles', './environments']
+    for cookbook_path in cookbook_paths:
+        paths_to_sync.append('./{0}'.format(cookbook_path))
+
     rsync_project(
         env.node_work_path,
-        './cookbooks ./data_bags ./roles ./site-cookbooks ./environments',
+        ' '.join(paths_to_sync),
         exclude=('*.svn', '.bzr*', '.git*', '.hg*'),
         delete=True,
         extra_opts=extra_opts,
@@ -305,6 +312,35 @@ def remove_local_node_data_bag():
     node_data_bag_path = os.path.join('data_bags', 'node')
     if os.path.exists(node_data_bag_path):
         shutil.rmtree(node_data_bag_path)
+
+
+def ensure_berksfile_cookbooks_are_installed():
+    """Run 'berks vendor' to berksfile cookbooks directory"""
+    msg = "Vendoring cookbooks from Berksfile {0} to directory {1}..."
+    print(msg.format(env.berksfile, env.berksfile_cookbooks_directory))
+
+    run_vendor = False
+    cookbooks_dir = env.berksfile_cookbooks_directory
+    cookbooks_dir_exists = os.path.isdir(cookbooks_dir)
+
+    if not cookbooks_dir_exists:
+        run_vendor = True
+
+    if cookbooks_dir_exists:
+        berksfile_mtime = os.stat('Berksfile').st_mtime
+        cookbooks_mtime = os.stat(cookbooks_dir).st_mtime
+        run_vendor = berksfile_mtime > cookbooks_mtime
+
+    if run_vendor:
+        if cookbooks_dir_exists:
+            shutil.rmtree(env.berksfile_cookbooks_directory)
+
+        p = subprocess.Popen(['berks', 'vendor', env.berksfile_cookbooks_directory],
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        # TODO: output better
+        print stdout, stderr
 
 
 def _remove_remote_node_data_bag():

--- a/littlechef/runner.py
+++ b/littlechef/runner.py
@@ -23,7 +23,7 @@ from fabric.contrib.console import confirm
 from paramiko.config import SSHConfig as _SSHConfig
 
 import littlechef
-from littlechef import solo, lib, chef
+from littlechef import solo, lib, chef, cookbook_paths
 
 # Fabric settings
 import fabric
@@ -133,6 +133,9 @@ def node(*nodes):
         # A list of nodes was given
         env.hosts = list(nodes)
     env.all_hosts = list(env.hosts)  # Shouldn't be needed
+
+    if env.berksfile:
+        chef.ensure_berksfile_cookbooks_are_installed()
 
     # Check whether another command was given in addition to "node:"
     if not(littlechef.__cooking__ and
@@ -502,6 +505,14 @@ def _readconfig():
         env.follow_symlinks = config.getboolean('kitchen', 'follow_symlinks')
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
         env.follow_symlinks = False
+
+    try:
+        env.berksfile = config.get('kitchen', 'berksfile')
+        env.berksfile_cookbooks_directory = config.get('kitchen', 'berksfile_cookbooks_directory')
+        littlechef.cookbook_paths.append(env.berksfile_cookbooks_directory)
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as e:
+        env.berksfile = None
+        env.berksfile_cookbooks_directory = None
 
 
 # Only read config if fix is being used and we are not creating a new kitchen


### PR DESCRIPTION
Aims at #166.  Very much WIP, need to write tests/formal documentation, wanted to get a sense whether this was the right direction.  (Wrote a bunch of tests for one approach that turned out not to work in parallel mode so backed them out.)

Workflow:

User updates the kitchen section of the littlechef.cfg:

```
[kitchen]
berksfile = Berksfile
berksfile_cookbooks_directory = berks-cookbooks
```

Before running any 'fix' commands littlechef does a berks vendor into that directory, removing it if it already exists.  It does not remove the directory if the directory is newer than the Berksfile.

Had to do this in the `node` call because anything later runs into parallel execution issues, we only want to run berks vendor in single threaded mode

Still TODO:
- check for berkshelf 3 when config is specified, die if not there (not sure how much of this would work for berkshelf 2 as I've only ever used 3)
- check for existence of Berksfile
- berks vendor fails = fix should fail

(I decided I liked this approach better than pre-deploy hooks.)
