### PR TITLE
Adds options to run littlechef outside of kitchen, fixes library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ from littlechef import runner as lc
 lc.env.user = 'MyUsername'
 lc.env.password = 'MyPassword'
 lc.env.host_string = 'MyHostnameOrIP'
-lc.deploy_chef(gems='yes', ask='no')
+lc.deploy_chef(ask='no')
 
 lc.recipe('MYRECIPE') #Applies <MYRECIPE> to <MyHostnameOrIP>
 lc.node('MyHostnameOrIP') #Applies the saved nodes/MyHostnameOrIP.json configuration

--- a/README.md
+++ b/README.md
@@ -365,6 +365,9 @@ lc.recipe('MYRECIPE') #Applies <MYRECIPE> to <MyHostnameOrIP>
 lc.node('MyHostnameOrIP') #Applies the saved nodes/MyHostnameOrIP.json configuration
 ```
 
+You will need to specify additional `lc.env` parameters per your requirements.
+A simple [working example](https://gist.github.com/iashwash/4dd3e6c655c545cb272f).
+
 ### Performance Tips
 
 You can greatly reduce the SSH connection setup time by reusing existing connections.

--- a/fix
+++ b/fix
@@ -109,9 +109,19 @@ def parse_arguments():
               "guests of matching hosts")
     )
     parser.add_argument(
+        "--kitchen-path", dest="kitchen_path", default=os.getcwd(),
+        help=("Path to the kitchen repository (containing cookbooks, databags,"
+              " nodes, etc.) - assumed to be the working directory if not provided.")
+    )
+    parser.add_argument(
         "--no-color", dest="no_color", action="store_true",
         default=False,
         help=("Don't colorize the output")
+    )
+    parser.add_argument(
+        "--skip-node-data-bag", dest="skip_node_data_bag", action="store_true",
+        default=False,
+        help=("Skips creation of the node databag.")
     )
     return parser, vars(parser.parse_args())
 
@@ -158,7 +168,10 @@ if __name__ == '__main__':
                 if not commands or ":" in args['environment']:
                     parser.error("No value given for --env")
                 littlechef.chef_environment = args['environment']
+            if args['skip_node_data_bag']:
+                littlechef.skip_node_data_bag = True
             littlechef.no_color = args['no_color']
+            littlechef.kitchen_path = args['kitchen_path']
 
             # overwrite all commandline arguments and proxy
             # execution to the fabric script

--- a/littlechef/__init__.py
+++ b/littlechef/__init__.py
@@ -14,12 +14,14 @@ Server users: data bag search, and node search.
 .. _Chef: http://wiki.opscode.com/display/chef/Home
 
 """
+import os
 __version__ = "1.8.0"
 __author__ = "Miquel Torres <tobami@gmail.com>"
 
 __cooking__ = False
 
 chef_environment = None
+kitchen_path = os.getcwd()
 
 loglevel = "info"
 noninteractive = False
@@ -29,6 +31,7 @@ LOGFILE = "/var/log/chef/solo.log"
 whyrun = False
 concurrency = False
 include_guests = False
+skip_node_data_bag = False
 no_color = False
 
 node_work_path = "/tmp/chef-solo"

--- a/littlechef/lib.py
+++ b/littlechef/lib.py
@@ -278,7 +278,7 @@ def get_recipes_in_cookbook(name):
     cookbook_exists = False
     metadata_exists = False
     for cookbook_path in cookbook_paths:
-        path = os.path.join(cookbook_path, name)
+        path = os.path.join(kitchen_relative_path(cookbook_path), name)
         path_exists = os.path.exists(path)
         # cookbook exists if present in any of the cookbook paths
         cookbook_exists = cookbook_exists or path_exists
@@ -324,7 +324,7 @@ def get_recipes_in_cookbook(name):
     # Add recipes found in the 'recipes' directory but not listed
     # in the metadata
     for cookbook_path in cookbook_paths:
-        recipes_dir = os.path.join(cookbook_path, name, 'recipes')
+        recipes_dir = os.path.join(kitchen_relative_path(cookbook_path), name, 'recipes')
         if not os.path.isdir(recipes_dir):
             continue
         for basename in os.listdir(recipes_dir):
@@ -368,6 +368,7 @@ def get_recipes():
     """Gets all recipes found in the cookbook directories"""
     dirnames = set()
     for path in cookbook_paths:
+        path = kitchen_relative_path(path)
         dirnames.update([d for d in os.listdir(path) if os.path.isdir(
                             os.path.join(path, d)) and not d.startswith('.')])
     recipes = []
@@ -457,6 +458,11 @@ def print_role(role, detailed=True):
     print("")
 
 
+def kitchen_relative_path(path):
+    """Returns path relative to chef kitchen path"""
+    return os.path.join(env.kitchen_path, path)
+
+
 def print_plugin_list():
     """Prints a list of available plugins"""
     print("List of available plugins:")
@@ -502,7 +508,7 @@ def import_plugin(name):
 def get_cookbook_path(cookbook_name):
     """Returns path to the cookbook for the given cookbook name"""
     for cookbook_path in cookbook_paths:
-        path = os.path.join(cookbook_path, cookbook_name)
+        path = os.path.join(kitchen_relative_path(cookbook_path), cookbook_name)
         if os.path.exists(path):
             return path
     raise IOError('Can\'t find cookbook with name "{0}"'.format(cookbook_name))

--- a/littlechef/runner.py
+++ b/littlechef/runner.py
@@ -33,7 +33,9 @@ env.loglevel = littlechef.loglevel
 env.verbose = littlechef.verbose
 env.abort_on_prompts = littlechef.noninteractive
 env.chef_environment = littlechef.chef_environment
+env.kitchen_path = littlechef.kitchen_path
 env.node_work_path = littlechef.node_work_path
+env.skip_node_data_bag = littlechef.skip_node_data_bag
 env.eagerly_disconnect = True
 env.no_color = littlechef.no_color
 
@@ -69,15 +71,16 @@ def new_kitchen():
         "run_list": ["recipe[apt]"]
     }
     content += "{0}".format(json.dumps(data, indent=2))
-    _mkdir("nodes", content)
-    _mkdir("roles")
-    _mkdir("data_bags")
-    _mkdir("environments")
+    _mkdir(lib.kitchen_relative_path("nodes"), content)
+    _mkdir(lib.kitchen_relative_path("roles"))
+    _mkdir(lib.kitchen_relative_path("data_bags"))
+    _mkdir(lib.kitchen_relative_path("environments"))
     for cookbook_path in littlechef.cookbook_paths:
-        _mkdir(cookbook_path)
+        _mkdir(lib.kitchen_relative_path(cookbook_path))
     # Add skeleton config file
-    if not os.path.exists(littlechef.CONFIGFILE):
-        with open(littlechef.CONFIGFILE, 'w') as configfh:
+    configfile = lib.kitchen_relative_path(littlechef.CONFIGFILE)
+    if not os.path.exists(configfile):
+        with open(configfile, 'w') as configfh:
             print >> configfh, "[userinfo]"
             print >> configfh, "user = "
             print >> configfh, "password = "
@@ -123,7 +126,9 @@ def nodes_with_tag(tag):
 
 def node(*nodes):
     """Selects and configures a list of nodes. 'all' configures all nodes"""
-    chef.build_node_data_bag()
+    if not env.skip_node_data_bag:
+        chef.build_node_data_bag()
+
     if not len(nodes) or nodes[0] == '':
         abort('No node was given')
     elif nodes[0] == 'all':
@@ -366,10 +371,10 @@ def _check_appliances():
     """Looks around and return True or False based on whether we are in a
     kitchen
     """
-    filenames = os.listdir(os.getcwd())
+    filenames = os.listdir(env.kitchen_path)
     missing = []
     for dirname in ['nodes', 'environments', 'roles', 'cookbooks', 'data_bags']:
-        if (dirname not in filenames) or (not os.path.isdir(dirname)):
+        if (dirname not in filenames) or (not os.path.isdir(lib.kitchen_relative_path(dirname))):
             missing.append(dirname)
     return (not bool(missing)), missing
 
@@ -377,8 +382,9 @@ def _check_appliances():
 def _readconfig():
     """Configures environment variables"""
     config = ConfigParser.SafeConfigParser()
+    configfile = lib.kitchen_relative_path(littlechef.CONFIGFILE)
     try:
-        found = config.read(littlechef.CONFIGFILE)
+        found = config.read(configfile)
     except ConfigParser.ParsingError as e:
         abort(str(e))
     if not len(found):
@@ -399,7 +405,8 @@ def _readconfig():
         abort("Couldn't find {0}. "
               "Are you executing 'fix' outside of a kitchen?\n"
               "To create a new kitchen in the current directory "
-              " type 'fix new_kitchen'".format(missing_str(missing)))
+              " type 'fix new_kitchen' or pass in --kitchen-path option"
+              " to specify an existing kitchen".format(missing_str(missing)))
 
     # We expect an ssh_config file here,
     # and/or a user, (password/keyfile) pair
@@ -515,6 +522,12 @@ def _readconfig():
         env.follow_symlinks = config.getboolean('kitchen', 'follow_symlinks')
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
         env.follow_symlinks = False
+
+    # Skip building the node data bag
+    try:
+        env.skip_node_data_bag = config.getboolean('kitchen', 'skip_node_data_bag')
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+        env.skip_node_data_bag = littlechef.skip_node_data_bag
 
     try:
         env.berksfile = config.get('kitchen', 'berksfile')


### PR DESCRIPTION
Library usage was difficult since littlechef needed to be run within the kitchen working directory.

I added an option to specify the path to kitchen and to skip node data bag building. With this and assuming a repository with prebuilt berks path, littlechef can be invoked without knife being installed on the system.

I also updated the library usage example. It contained an old way to invoke the deploy_chef function, and I added a link to a more detailed working example of invoking littlechef (since you have to specify many env variables to get it to run).

Tested fix and library invocations manually. Need a little guidance on getting the tests to run before I would consider this merge-able, since I should add some test cases. How do you invoke the testing suite?